### PR TITLE
GstGLPlayer - fix color format and memory leak

### DIFF
--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -83,7 +83,7 @@ class VideoBase(EventDispatcher):
             self.eos = 'stop'
         self.filename = kwargs.get('filename')
 
-        Clock.schedule_interval(self._update, 0)
+        Clock.schedule_interval(self._update, 1 / 30.)
 
         if self._autoplay:
             self.play()

--- a/kivy/core/video/video_gstglplayer.py
+++ b/kivy/core/video/video_gstglplayer.py
@@ -8,12 +8,13 @@ Implementation of a VideoBase with Kivy :class:`~kivy.lib.gstglplayer.GstGLPlaye
 Uses Gstreamer 1.0's OpenGL support for smooth video playback on supported platforms.
 '''
 
-from kivy.lib.gstglplayer import GstGLPlayer, get_gst_version
-from kivy.graphics.texture import Texture
-from kivy.core.video import VideoBase
-from kivy.logger import Logger
 from kivy.clock import Clock
 from kivy.compat import PY2
+from kivy.core.video import VideoBase
+from kivy.graphics.texture import Texture
+from kivy.graphics.opengl import GL_TEXTURE_2D
+from kivy.lib.gstglplayer import GstGLPlayer, get_gst_version
+from kivy.logger import Logger
 from threading import Lock
 from functools import partial
 from os.path import realpath
@@ -41,16 +42,8 @@ class VideoGstGLplayer(VideoBase):
 
     def __init__(self, **kwargs):
         self.player = None
-
-        self._texture_store = {}
         self._next_texture = None
-        
-        # Very ugly hack to get texture target property, needed by Texture's default constructor.
-        # The value it references isn't availible any other way, needs to be exposed to Python TODO
-        self._texture_target = Texture.create(size = (1, 2)).target
-        
         self._on_load_called = False
-
         super(VideoGstGLplayer, self).__init__(**kwargs)
 
     def _on_gst_eos_sync(self):
@@ -68,8 +61,6 @@ class VideoGstGLplayer(VideoBase):
         if self.player:
             self.player.unload()
             self.player = None
-
-        self._texture_store = {}
 
     def stop(self):
         super(VideoGstGLplayer, self).stop()
@@ -99,28 +90,24 @@ class VideoGstGLplayer(VideoBase):
             self.player.set_volume(self._volume)
 
     def _update(self, dt):
-        if self._next_texture:
-            self._texture = self._next_texture
-            self._next_texture = None
-            
-            self.dispatch('on_frame')            
-
-    def _update_texture(self, width, height, tex_id):
-        print('update_texture!', width, height, tex_id)
-
-        texture = self._texture_store.get(tex_id)
-        if not texture or not texture.size[0] == width or not texture.size[1] == height:
-            texture = Texture(width, height, self._texture_target, colorfmt = 'rgba', texid = tex_id)
-            texture.flip_vertical()
-            
-            self._texture_store[tex_id] = texture
-            
+        if self._texture:
             # There's probably a better way to do this, TODO
             if not self._on_load_called:
                 self.dispatch('on_load')
                 self._on_load_called = True
-        
-        self._next_texture = texture
+
+            self.dispatch('on_frame')
+
+    def _update_texture(self, width, height, tex_id):
+        self._texture = texture = Texture(
+            width,
+            height,
+            GL_TEXTURE_2D,
+            texid=tex_id,
+        )
+        texture.flip_vertical()
+
+        return texture
 
     def _get_uri(self):
         uri = self.filename

--- a/kivy/graphics/fbo.pxd
+++ b/kivy/graphics/fbo.pxd
@@ -27,4 +27,4 @@ cdef class Fbo(RenderContext):
     cdef int apply(self) except -1
     cdef void raise_exception(self, str message, int status=?)
     cdef str resolve_status(self, int status)
-    cdef void reload(self)
+    cdef void reload(self) except *

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -360,7 +360,7 @@ cdef class Fbo(RenderContext):
             self.flag_update_done()
         return 0
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         # recreate the framebuffer, without deleting it. the deletion is not
         # handled by us.
         self.create_fbo()

--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -33,7 +33,7 @@ cdef class Instruction(ObjectWithUid):
         cpdef flag_update(self, int do_parent=?)
     cdef void flag_update_done(self)
     cdef void set_parent(self, Instruction parent)
-    cdef void reload(self)
+    cdef void reload(self) except *
 
     cdef void radd(self, InstructionGroup ig)
     cdef void rinsert(self, InstructionGroup ig, int index)
@@ -44,7 +44,7 @@ cdef class InstructionGroup(Instruction):
     cdef InstructionGroup compiled_children
     cdef GraphicsCompiler compiler
     cdef void build(self)
-    cdef void reload(self)
+    cdef void reload(self) except *
     cpdef add(self, Instruction c)
     cpdef insert(self, int index, Instruction c)
     cpdef remove(self, Instruction c)
@@ -94,7 +94,7 @@ cdef class Canvas(CanvasBase):
     cdef float _opacity
     cdef CanvasBase _before
     cdef CanvasBase _after
-    cdef void reload(self)
+    cdef void reload(self) except *
     cpdef clear(self)
     cpdef add(self, Instruction c)
     cpdef remove(self, Instruction c)
@@ -122,6 +122,6 @@ cdef class RenderContext(Canvas):
     cdef int leave(self) except -1
     cdef int apply(self) except -1
     cpdef draw(self)
-    cdef void reload(self)
+    cdef void reload(self) except *
 
 cdef RenderContext getActiveContext()

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -95,7 +95,7 @@ cdef class Instruction(ObjectWithUid):
     cdef void set_parent(self, Instruction parent):
         self.parent = parent
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         self.flags |= GI_NEEDS_UPDATE
         self.flags &= ~GI_NO_APPLY_ONCE
         self.flags &= ~GI_IGNORE
@@ -223,7 +223,7 @@ cdef class InstructionGroup(Instruction):
         cdef Instruction c
         return [c for c in self.children if c.group == groupname]
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         Instruction.reload(self)
         cdef Instruction c
         for c in self.children:
@@ -574,7 +574,7 @@ cdef class Canvas(CanvasBase):
         self._before = None
         self._after = None
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         return
         '''
         # XXX ensure it's not needed anymore.
@@ -868,7 +868,7 @@ cdef class RenderContext(Canvas):
 
         return 0
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         pushActiveContext(self)
         reset_gl_context()
         Canvas.reload(self)

--- a/kivy/lib/gstglplayer/_gstgl.c
+++ b/kivy/lib/gstglplayer/_gstgl.c
@@ -89,20 +89,18 @@ void gst_gl_stop_pipeline (GstPipeline *pipeline) {
     
     gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_NULL);
 
-    glXMakeCurrent (x11_display, None, 0);
+    SDL_GL_MakeCurrent(sdl_window, NULL);
     
     GST_OBJECT_UNLOCK(GST_OBJECT (gst_gl_display));
 }
 
 unsigned int
-get_texture_id_from_buffer (GstBuffer *buf, guint width, guint height)
+get_texture_id_from_buffer (GstBuffer *buf, GstVideoInfo *v_info)
 {
   GstVideoFrame v_frame;
-  GstVideoInfo v_info;
   guint texture = 0;
   
-  
-  if (!gst_video_frame_map (&v_frame, &v_info, buf, GST_MAP_READ | GST_MAP_GL)) {
+  if (!gst_video_frame_map (&v_frame, v_info, buf, (GstMapFlags) (GST_MAP_READ | GST_MAP_GL))) {
     g_warning ("Failed to map the video buffer");
     return texture;
   }

--- a/kivy/lib/gstglplayer/_gstgl.c
+++ b/kivy/lib/gstglplayer/_gstgl.c
@@ -101,7 +101,6 @@ get_texture_id_from_buffer (GstBuffer *buf, guint width, guint height)
   GstVideoInfo v_info;
   guint texture = 0;
   
-  gst_video_info_set_format (&v_info, GST_VIDEO_FORMAT_RGBA, width, height);
   
   if (!gst_video_frame_map (&v_frame, &v_info, buf, GST_MAP_READ | GST_MAP_GL)) {
     g_warning ("Failed to map the video buffer");

--- a/kivy/lib/gstglplayer/_gstgl.h
+++ b/kivy/lib/gstglplayer/_gstgl.h
@@ -1,4 +1,5 @@
 #include <gst/gst.h>
+#include <gst/video/video-info.h>
 
 #include "SDL2/SDL.h"
 
@@ -6,4 +7,4 @@ void gst_gl_init (SDL_Window *window);
 void gst_gl_set_bus_cb (GstBus *bus);
 void gst_gl_stop_pipeline (GstPipeline *pipeline);
 
-guint get_texture_id_from_buffer (GstBuffer *buf, guint width, guint height);
+guint get_texture_id_from_buffer (GstBuffer *buf, GstVideoInfo *v_info);

--- a/kivy/lib/gstglplayer/_gstglplayer.h
+++ b/kivy/lib/gstglplayer/_gstglplayer.h
@@ -31,10 +31,9 @@ static void g_object_set_int(GstElement *element, char *name, int value)
 	g_object_set(G_OBJECT(element), name, value, NULL);
 }
 
-static void dump_dot_file(GstPipeline *pipeline, const gchar *filename)
+static void dump_dot_file(GstElement *pipeline, const gchar *filename)
 {
-    
-    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, filename);
+    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(GST_PIPELINE(pipeline)), GST_DEBUG_GRAPH_SHOW_ALL, filename);
 }
 
 typedef void (*appcallback_t)(void *, int, int, char *, int);

--- a/kivy/lib/gstglplayer/_gstglplayer.pyx
+++ b/kivy/lib/gstglplayer/_gstglplayer.pyx
@@ -354,7 +354,7 @@ cdef class GstGLPlayer:
             if self.appsink == NULL:
                 raise GstGLPlayerException('Unable to create an appsink')
 
-            g_object_set_caps(self.appsink, 'video/x-raw(memory:GLMemory), format=RGBA')
+            g_object_set_caps(self.appsink, 'video/x-raw(memory:GLMemory), format=RGB')
             g_object_set_int(self.appsink, 'max-buffers', 5)
             g_object_set_int(self.appsink, 'drop', 1)
             g_object_set_int(self.appsink, 'sync', 1)

--- a/setup.py
+++ b/setup.py
@@ -479,25 +479,7 @@ if c_options['use_sdl2'] or (
             c_options['use_sdl2'] = True
 
 
-if platform == 'linux' and c_options['use_sdl2']:
-    gst_app_flags = pkgconfig('gstreamer-app-1.0')
-    gst_gl_flags = pkgconfig('gstreamer-gl-1.0')
-    if 'libraries' in gst_app_flags and 'libraries' in gst_gl_flags:
-        c_options['use_gstreamer_gl'] = True
-
-if platform == 'linux' and c_options['use_sdl2']:
-    gst_app_flags = pkgconfig('gstreamer-app-1.0')
-    gst_gl_flags = pkgconfig('gstreamer-gl-1.0')
-    if 'libraries' in gst_app_flags and 'libraries' in gst_gl_flags:
-        c_options['use_gstreamer_gl'] = True
-
-if platform == 'linux' and c_options['use_sdl2']:
-    gst_app_flags = pkgconfig('gstreamer-app-1.0')
-    gst_gl_flags = pkgconfig('gstreamer-gl-1.0')
-    if 'libraries' in gst_app_flags and 'libraries' in gst_gl_flags:
-        c_options['use_gstreamer_gl'] = True
-
-if platform == 'linux' and c_options['use_sdl2']:
+if platform.startswith('linux') and c_options['use_sdl2']:
     gst_app_flags = pkgconfig('gstreamer-app-1.0')
     gst_gl_flags = pkgconfig('gstreamer-gl-1.0')
     if 'libraries' in gst_app_flags and 'libraries' in gst_gl_flags:


### PR DESCRIPTION
These are my attempts at fixing GstGLPlayer - for now I can read a video properly (no visual artifacts due to wrong color format) and not have a massive memory leak with each frame.

When stopping a video or reaching EOS we hit a deadlock at this point - I have not investigated this issue at all yet.